### PR TITLE
Update FlexImage.php to de-/publish images correctly

### DIFF
--- a/system/modules/flexslider/library/FlexSlider/Model/FlexImage.php
+++ b/system/modules/flexslider/library/FlexSlider/Model/FlexImage.php
@@ -26,9 +26,11 @@ class FlexImage extends \Model {
 	
 	
 	public static function updatePublished() {
-		Database::getInstance()->prepare("UPDATE tl_flex_image SET published='1' WHERE (start <= ? AND start != '') AND (stop >= ? OR stop = '')")->execute(time(), time());
-		Database::getInstance()->prepare("UPDATE tl_flex_image SET published='' WHERE stop <= ? AND stop != ''")->execute(time());
+		// rows should not be updated when neither start nor stop are filled
+		$time = time();
+		Database::getInstance()->prepare("UPDATE tl_flex_image SET published = '1' WHERE start != '' AND start <= ? AND (stop = '' OR stop >= ?) OR stop != '' AND stop >= ? AND (start = '' OR start <= ?)")->execute($time, $time, $time, $time);
+		Database::getInstance()->prepare("UPDATE tl_flex_image SET published = '' WHERE start != '' AND start > ? OR stop != '' AND stop < ?")->execute($time, $time);
 	}
-	
+
 }
 ?>


### PR DESCRIPTION
Hi,

I've tried and found a solution to this issue:
fixes #3 

The new conditions update the `published`-col depending on the values of `start` and `stop`, but do nothing if both values are empty. In this case, the user should set the `published`-value manually.

I've tested against the following matrix (it defines the conditions in each updated SQL-query respectively):

|   | Change to '1' |   | Change to '' |   |
| - | ------------- | - | ------------ | - |
| | TARGET | ACTUAL | TARGET | ACTUAL |
| start is empty, stop is empty | false | false | false | false |
| | | | | |
| start is empty, stop in the future | true | true | false | false |
| start is empty, stop in the past | false | false | true | true |
| | | | | |
| start in the future, stop is empty | false | false | true | true |
| start in the past, stop is empty | true | true | false | false |
| | | | | |
| start in the future, stop in the future | false | false | true | true |
| start in the past, stop in the past | false | false | true | true |
| | | | | |
| start in the future, stop in the past | false | false | true | true |
| start in the past, stop in the future | true | true | false | false |

Please let me know what you think :-) thanks!