### PR TITLE
Update ce_flexslider.html5 to fix datasources for carousel-slider

### DIFF
--- a/system/modules/flexslider/templates/content/ce_flexslider.html5
+++ b/system/modules/flexslider/templates/content/ce_flexslider.html5
@@ -36,7 +36,7 @@
          <div id="<?php echo $this->configuration['alias']; ?>" class="<?php echo $this->configuration['css_theme']; ?>">
         <div id="slider" class="flexslider">
           <ul class="slides">
-        <?php foreach ($this->pictures as $pictures): 
+        <?php foreach ($this->images as $arrImage): 
 		      	if ($arrImage['linkTarget'] == '' && $arrImage['attributes'] == ''):?>
 		     		<li>
                     <img alt="<?php echo $arrImage['alt']; ?>" src="<?php echo $arrImage['singleSRC']; ?>" />
@@ -61,7 +61,7 @@
         </div>
         <div id="carousel" class="flexslider">
            <ul class="slides" style="margin-left: -<?php echo $this->configuration['itemMargin']?>px">
-        <?php foreach ($this->pictures as $pictures): ?>
+        <?php foreach ($this->images as $arrImage): ?>
           <?php echo '<li style="margin-left: '.$this->configuration['itemMargin'].'px"><img alt="'.$arrImage['alt'].'" src="'.$arrImage['singleSRC'].'" />'; ?> 
         <?php endforeach; ?>
           </ul>


### PR DESCRIPTION
Hi again :-)

there is an error in the image-iteration, if the gallery is in "carousel"-mode (if you select "show thumbnails" in the slider-settings).

The variable used to iterate the images is not correct and thus does not contain any entries. The updated variable is the same as in the "normal" (non-carousel) slider.